### PR TITLE
Add link to Smith archivesspace Python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ArchivesSnake
 Repo for all AS Python Related work
 
+* [Smith archivesspace Python Module](https://smithcollegelibraries.github.io/archivesspace-python/)
 * [RAC Examples](RAC_links.md)
 * [Duke Examples](Duke_links.md)
 * [Outline of UAlbany Draft Library](ualbanyExample.md)


### PR DESCRIPTION
I'm adding a link to my pet project which is an easy to use Python module for interfacing with the AS API.