### PR TITLE
Include params in get_paged

### DIFF
--- a/asnake/client/web_client.py
+++ b/asnake/client/web_client.py
@@ -77,7 +77,7 @@ class ASnakeClient(metaclass=ASnakeProxyMethods):
         '''get list of json objects from urls of paged items'''
         params = {"page_size": page_size, "page": 1}
         if "params" in kwargs:
-            params.update(**kwargs)
+            params.update(**kwargs['params'])
             del kwargs['params']
 
         current_page = self.get(url, params=params, **kwargs)


### PR DESCRIPTION
When making a request using the `get_paged` method, I would expect that something like:
```
c.get_paged('delete_feed', params={'last_modified': 1234})
``` 
would produce a request like: 
```
/delete_feed?page_size=10&page=1&last_modified=1234
``` 

However, since the `update()` call was dumping the entire contents of `kwargs`, I got something more like:
```
/delete_feed?page_size=10&page=1&params=last_modified
```

This fixes that 🐛