### PR TITLE
Adding super big bold clarification on log config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Default values corresponding to the admin account of an unaltered local developm
 
 ### Logging
 
-ArchivesSnake uses [structlog](http://www.structlog.org/en/stable/) combined with the stdlib logging module to provide configurable logging with reasonable defaults.  By default, log level is INFO, logging's default formatting is suppressed, and the log entries are formatted as line-oriented JSON and sent to standard error.  All of this can be configured; note that configuration must happen prior to loading asnake.client.ASnakeClient or any of module that uses it, like so:
+ArchivesSnake uses [structlog](http://www.structlog.org/en/stable/) combined with the stdlib logging module to provide configurable logging with reasonable defaults.  By default, log level is INFO, logging's default formatting is suppressed, and the log entries are formatted as line-oriented JSON and sent to standard error.  All of this can be configured; note that configuration must happen prior to **(ANY)** loading asnake.client.ASnakeClient or any of module that uses it **INCLUDING THE IMPORT STATEMENT**, like so:
 
 ``` python
 import asnake.logging as logging


### PR DESCRIPTION
For those like me who don't parse import statements as "loading" because
we assume it involves somehow otherwise loading the client. The example is great though so that doesn't need changing.

  _                                    __                  _
 | |_  __ ___ _____   _  _ ___ _  _   / _|___ _  _ _ _  __| |
 | ' \/ _` \ V / -_) | || / _ \ || | |  _/ _ \ || | ' \/ _` |
 |_||_\__,_|\_/\___|  \_, \___/\_,_| |_| \___/\_,_|_||_\__,_|
                      |__/

  _   _                   _ _                 _
 | |_| |_  ___   _  _ ___| | |_____ __ __  __(_)__ _ _ _
 |  _| ' \/ -_) | || / -_) | / _ \ V  V / (_-< / _` | ' \
  \__|_||_\___|  \_, \___|_|_\___/\_/\_/  /__/_\__, |_||_|
                 |__/                          |___/